### PR TITLE
Update GitHub Actions workflow: Correct pull request number retrieval

### DIFF
--- a/.github/workflows/github-actions-setup.yml
+++ b/.github/workflows/github-actions-setup.yml
@@ -24,4 +24,4 @@ jobs:
         run: echo "PULL_REQUEST_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
       - name: Test Endpoint
         run: |
-          curl -X POST -H "Content-Type: application/json" -d '{"pull_request_number": "${{ env.PULL_REQUEST_NUMBER }}" }' https://35bd-23-112-11-217.ngrok-free.app/review_build_error_logs
+          curl -X POST -H "Content-Type: application/json" -d {"pull_request_number": "${{ env.PULL_REQUEST_NUMBER }}"} https://35bd-23-112-11-217.ngrok-free.app/review_build_error_logs


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to explicitly set the pull request number as an environment variable and use it in the curl command.